### PR TITLE
Miria: Fix Group Policy related crashes (#2212)

### DIFF
--- a/Ryujinx.Input.SDL2/SDL2Driver.cs
+++ b/Ryujinx.Input.SDL2/SDL2Driver.cs
@@ -25,7 +25,7 @@ namespace Ryujinx.Input.SDL2
             }
         }
 
-        private const uint SdlInitFlags = SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC | SDL_INIT_SENSOR;
+        private const uint SdlInitFlags = SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK;
 
         private bool _isRunning;
         private uint _refereceCount;


### PR DESCRIPTION
We actually don't need to init sensors or haptic to get motion or rumble
working on game controllers.

This fix a group policy issue on some Windows 10 Pro when trying to init
the SDL2 sensors APIs.